### PR TITLE
feat(cloud): add digital ocean cli to cloud base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ Adds AWS cloud tools to the Base images
 
 ![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)
 ![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)
+![DigitalOcean](https://img.shields.io/badge/DigitalOcean-%230167ff.svg?style=for-the-badge&logo=digitalOcean&logoColor=white)
 
 ### Tools
 
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
 - [Terraform](https://www.terraform.io/)
+- [Digital Ocean CLI](https://docs.digitalocean.com/reference/doctl/)
 
 ## Node
 

--- a/containers/Cloud.Dockerfile
+++ b/containers/Cloud.Dockerfile
@@ -1,7 +1,9 @@
-FROM ghcr.io/dotmh/devcontainer:1.0.0
+FROM ghcr.io/dotmh/devcontainer:latest
 
-LABEL org.opencontainers.image.source https://github.com/dotmh/devcontainer
-LABEL org.opencontainers.image.licenses apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/dotmh/devcontainer
+LABEL org.opencontainers.image.licenses=apache-2.0
+
+ARG digitalocean_cli_version=1.110.0
 
 # Install Terraform
 RUN wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg &&\
@@ -12,3 +14,8 @@ RUN wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" &&\
     unzip awscliv2.zip &&\
     sudo ./aws/install
+
+# Install Digital Ocean CLI
+RUN curl -L "https://github.com/digitalocean/doctl/releases/download/v${digitalocean_cli_version}/doctl-${digitalocean_cli_version}-linux-amd64.tar.gz" -o "doctl.tar.gz" &&\
+    tar xf ./doctl.tar.gz &&\
+    mv doctl /usr/local/bin

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
-LABEL org.opencontainers.image.source https://github.com/dotmh/devcontainer
-LABEL org.opencontainers.image.licenses apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/dotmh/devcontainer
+LABEL org.opencontainers.image.licenses=apache-2.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/containers/Go.Dockerfile
+++ b/containers/Go.Dockerfile
@@ -2,8 +2,8 @@ ARG base=devcontainer
 
 FROM ghcr.io/dotmh/${base}:latest
 
-LABEL org.opencontainers.image.source https://github.com/dotmh/devcontainer
-LABEL org.opencontainers.image.licenses apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/dotmh/devcontainer
+LABEL org.opencontainers.image.licenses=apache-2.0
 
 ARG go_version=1.22.3
 

--- a/containers/Kotlin.Dockerfile
+++ b/containers/Kotlin.Dockerfile
@@ -2,8 +2,8 @@ ARG base=devcontainer
 
 FROM ghcr.io/dotmh/${base}:latest
 
-LABEL org.opencontainers.image.source https://github.com/dotmh/devcontainer
-LABEL org.opencontainers.image.licenses apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/dotmh/devcontainer
+LABEL org.opencontainers.image.licenses=apache-2.0
 
 # Install SDKMan to manage Kotlin
 RUN curl -s "https://get.sdkman.io" | bash

--- a/containers/Node.Dockerfile
+++ b/containers/Node.Dockerfile
@@ -1,8 +1,8 @@
 ARG base=devcontainer
 FROM ghcr.io/dotmh/${base}:latest
 
-LABEL org.opencontainers.image.source https://github.com/dotmh/devcontainer
-LABEL org.opencontainers.image.licenses apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/dotmh/devcontainer
+LABEL org.opencontainers.image.licenses=apache-2.0
 
 ARG EXTRA_NODE_VERSION=--lts
 

--- a/containers/Rocky.Cloud.Dockerfile
+++ b/containers/Rocky.Cloud.Dockerfile
@@ -1,7 +1,9 @@
 FROM ghcr.io/dotmh/devcontainer-rocky:latest
 
-LABEL org.opencontainers.image.source https://github.com/dotmh/devcontainer
-LABEL org.opencontainers.image.licenses apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/dotmh/devcontainer
+LABEL org.opencontainers.image.licenses=apache-2.0
+
+ARG digitalocean_cli_version=1.110.0
 
 # Install Terraform
 RUN dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo &&\
@@ -12,3 +14,8 @@ RUN dnf -y install unzip &&\
     curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" &&\
     unzip awscliv2.zip &&\
     ./aws/install
+
+# Install Digital Ocean CLI
+RUN curl -L "https://github.com/digitalocean/doctl/releases/download/v${digitalocean_cli_version}/doctl-${digitalocean_cli_version}-linux-amd64.tar.gz" -o "doctl.tar.gz" &&\
+    tar xf ./doctl.tar.gz &&\
+    mv doctl /usr/local/bin

--- a/containers/Rocky.Dockerfile
+++ b/containers/Rocky.Dockerfile
@@ -1,8 +1,8 @@
 FROM rockylinux:9.3
 
 LABEL dev.containers.features="common"
-LABEL org.opencontainers.image.source https://github.com/dotmh/devcontainer
-LABEL org.opencontainers.image.licenses apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/dotmh/devcontainer
+LABEL org.opencontainers.image.licenses=apache-2.0
 
 # Set up  extended repos
 RUN dnf -y install dnf-plugins-core &&\

--- a/devcontainers/cloud/README.md
+++ b/devcontainers/cloud/README.md
@@ -1,11 +1,12 @@
 # DotMH Dev Container - Cloud
 
-A very simply base template it is just the OS ether Ubuntu or Rocky Linux with some quailty of life tools and cloud tools for working with Terraform and AWS. 
+A very simply base template it is just the OS ether Ubuntu or Rocky Linux with some quailty of life tools and cloud tools for working with Terraform and AWS.
 
 ![Static Badge](https://img.shields.io/badge/Rocky_Linux-10B981?style=for-the-badge&logo=rockylinux&logoColor=%23FFFFFF)
 ![Static Badge](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=%23FFFFFF)
 ![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)
 ![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)
+![DigitalOcean](https://img.shields.io/badge/DigitalOcean-%230167ff.svg?style=for-the-badge&logo=digitalOcean&logoColor=white)
 
 - [Rocky Linux](https://rockylinux.org/)
 - [Ubuntu](https://ubuntu.com/)
@@ -18,6 +19,7 @@ A very simply base template it is just the OS ether Ubuntu or Rocky Linux with s
 - [EZA](https://github.com/eza-community/eza) - A better ls command
 - [Just](https://github.com/casey/just) - An awesome task runner
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+- [Digital Ocean CLI](https://docs.digitalocean.com/reference/doctl/)
 - [Terraform](https://www.terraform.io/)
 
 ## Usage
@@ -35,5 +37,5 @@ devcontainer templates apply -w . -t ghcr.io/dotmh/devcontainer/cloud -a '{"base
 #### Options
 
 - `baseContainer` :
-    - `devcontainer-cloud` _DEFAULT_ - the ubuntu base container
-    - `devcontainer-rocky-cloud` - the rocky linux base container
+  - `devcontainer-cloud` _DEFAULT_ - the ubuntu base container
+  - `devcontainer-rocky-cloud` - the rocky linux base container

--- a/devcontainers/go/README.md
+++ b/devcontainers/go/README.md
@@ -20,12 +20,14 @@ A Devcontainer for use with Go development, optionally with tools for working wi
 - [PNPM](https://pnpm.io/)
 - [NVM \[Node Version Manager\]](https://github.com/nvm-sh/nvm)
 
-### When Using Cloud containers as the base 
+### When Using Cloud containers as the base
 
 ![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)
 ![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)
+![DigitalOcean](https://img.shields.io/badge/DigitalOcean-%230167ff.svg?style=for-the-badge&logo=digitalOcean&logoColor=white)
 
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+- [Digital Ocean CLI](https://docs.digitalocean.com/reference/doctl/)
 - [Terraform](https://www.terraform.io/)
 
 ## Visual Studio Extentions
@@ -35,8 +37,6 @@ A Devcontainer for use with Go development, optionally with tools for working wi
 When using this devcontainer under [Visual Studio Code (vscode)](https://code.visualstudio.com/) with the
 [Devcontainer Extention](https://containers.dev/supporting#visual-studio-code), vscode will automatically install
 the following extentions
-
-
 
 - [A Spellchecker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
 - [Go](https://marketplace.visualstudio.com/items?itemName=golang.go)
@@ -60,7 +60,7 @@ devcontainer templates apply -w . -t ghcr.io/dotmh/devcontainer/go -a '{"baseCon
 #### Options
 
 - `baseContainer` :
-    - `devcontainer` _DEFAULT_ - the ubuntu base container
-    - `devcontainer-rocky` - the rocky linux base container
-    - `devcontainer-cloud`- the ubuntu base container with cloud tools
-    - `devcontainer-rocky-cloud` - the rocky linux base container with cloud tools
+  - `devcontainer` _DEFAULT_ - the ubuntu base container
+  - `devcontainer-rocky` - the rocky linux base container
+  - `devcontainer-cloud`- the ubuntu base container with cloud tools
+  - `devcontainer-rocky-cloud` - the rocky linux base container with cloud tools

--- a/devcontainers/kotlin/README.md
+++ b/devcontainers/kotlin/README.md
@@ -24,8 +24,10 @@ A Devcontainer for use with Kotlin development, optionally with tools for workin
 
 ![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)
 ![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)
+![DigitalOcean](https://img.shields.io/badge/DigitalOcean-%230167ff.svg?style=for-the-badge&logo=digitalOcean&logoColor=white)
 
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+- [Digital Ocean CLI](https://docs.digitalocean.com/reference/doctl/)
 - [Terraform](https://www.terraform.io/)
 
 ## Visual Studio Extentions

--- a/devcontainers/node/README.md
+++ b/devcontainers/node/README.md
@@ -22,12 +22,14 @@ A Devcontainer for use with NodeJS development, optionally with tools for workin
 - [PNPM](https://pnpm.io/)
 - [NVM \[Node Version Manager\]](https://github.com/nvm-sh/nvm)
 
-### When Using Cloud containers as the base 
+### When Using Cloud containers as the base
 
 ![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)
 ![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)
+![DigitalOcean](https://img.shields.io/badge/DigitalOcean-%230167ff.svg?style=for-the-badge&logo=digitalOcean&logoColor=white)
 
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html)
+- [Digital Ocean CLI](https://docs.digitalocean.com/reference/doctl/)
 - [Terraform](https://www.terraform.io/)
 
 ## Visual Studio Extentions
@@ -37,8 +39,6 @@ A Devcontainer for use with NodeJS development, optionally with tools for workin
 When using this devcontainer under [Visual Studio Code (vscode)](https://code.visualstudio.com/) with the
 [Devcontainer Extention](https://containers.dev/supporting#visual-studio-code), vscode will automatically install
 the following extentions
-
-
 
 - [A Spellchecker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)
 - [Prettier Extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
@@ -70,7 +70,7 @@ devcontainer templates apply -w . -t ghcr.io/dotmh/devcontainer/node -a '{"baseC
 #### Options
 
 - `baseContainer` :
-    - `devcontainer` _DEFAULT_ - the ubuntu base container
-    - `devcontainer-rocky` - the rocky linux base container
-    - `devcontainer-cloud`- the ubuntu base container with cloud tools
-    - `devcontainer-rocky-cloud` - the rocky linux base container with cloud tools
+  - `devcontainer` _DEFAULT_ - the ubuntu base container
+  - `devcontainer-rocky` - the rocky linux base container
+  - `devcontainer-cloud`- the ubuntu base container with cloud tools
+  - `devcontainer-rocky-cloud` - the rocky linux base container with cloud tools


### PR DESCRIPTION
- Adds Digital Ocean CLI to the cloud base images (Ubuntu and Rocky)
- Adds the documentation to the readme
- Fixes out of-date syntax on docker LABEL (LABEL name value has been deprecated in favour of LABEL name=value)